### PR TITLE
Update the sourcecred dependency

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,7 @@ steps:
       - echo "$SSH_BOT_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa
       - mkdir site
       - ./scripts/prepare_weights.sh
-      - sourcecred/scripts/build_static_site.sh --target ./site --repo sfosc/sfosc --repo sfosc/wizard --cname sfosc.org
+      - sourcecred/scripts/build_static_site.sh --target ./site --repo sfosc/sfosc --repo sfosc/wizard --cname sfosc.org --weights .weights.json
 
   - name: commit-and-push
     image: docker:git

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /sourcecred_data
 /secrets
+.weights.json

--- a/scripts/local-debug.sh
+++ b/scripts/local-debug.sh
@@ -7,13 +7,13 @@ cd mkweights
 npm i
 cd ..
 
-cat ./weights.toml | node mkweights > sourcecred/weights.json
+cat ./weights.toml | node mkweights > .weights.json
 
 cd sourcecred
 yarn install
 yarn backend
 
-SOURCECRED_GITHUB_TOKEN=$SOURCECRED_GITHUB_TOKEN node bin/sourcecred.js load sfosc/sfosc
-SOURCECRED_GITHUB_TOKEN=$SOURCECRED_GITHUB_TOKEN node bin/sourcecred.js load sfosc/wizard
+SOURCECRED_GITHUB_TOKEN=$SOURCECRED_GITHUB_TOKEN node bin/sourcecred.js load sfosc/sfosc --weights ../.weights.json
+SOURCECRED_GITHUB_TOKEN=$SOURCECRED_GITHUB_TOKEN node bin/sourcecred.js load sfosc/wizard --weights ../.weights.json
 
 yarn start

--- a/scripts/prepare_weights.sh
+++ b/scripts/prepare_weights.sh
@@ -2,11 +2,11 @@
 # Make sure the pwd is the root of the repository.
 
 # Rebuild weight overrides from root toml file.
-rm sourcecred/weights.json
+rm .weights.json
 if [ -e "weights.toml" ]; then
 	echo "Converting weights.toml"
 	cd mkweights
 	npm install --production
 	cd ..
-	cat weights.toml | node mkweights > sourcecred/weights.json
+	cat weights.toml | node mkweights > .weights.json
 fi


### PR DESCRIPTION
Now using v0.3.0 (Timeline cred) as the base.
Still includes some modifications from my fork to:
- Allow weight overrides during build-time.
- Increase number of entries shown in tables and charts.