### PR TITLE
Buffer scores into a file for local development too.

### DIFF
--- a/scripts/local-generate-svg.sh
+++ b/scripts/local-generate-svg.sh
@@ -47,5 +47,8 @@ export SVG_MIN_CRED=4.5
 export SVG_MAX_USERS=50
 for repo in $REPOS; do
 	echo "Generating ${repo//\//-}-contributors.svg"
-	node ../sourcecred/bin/sourcecred.js scores $repo | SOURCECRED_GITHUB_TOKEN=$SOURCECRED_GITHUB_TOKEN ./bin/contributor-wall-svg.js > "../${repo//\//-}-contributors.svg"
+	# Buffer the score output to a file to prevent occasional read errors from STDIN.
+	node ../sourcecred/bin/sourcecred.js scores $repo > "../${repo//\//-}-contributors.json"
+	SOURCECRED_GITHUB_TOKEN=$SOURCECRED_GITHUB_TOKEN ./bin/contributor-wall-svg.js < "../${repo//\//-}-contributors.json" > "../${repo//\//-}-contributors.svg"
+	rm "../${repo//\//-}-contributors.json"
 done


### PR DESCRIPTION
Locally generating SVGs had the same EAGAIN bug.
See https://github.com/sourcecred/widgets/issues/14