### PR TITLE
Tweak widget parameters

### DIFF
--- a/scripts/local-generate-svg.sh
+++ b/scripts/local-generate-svg.sh
@@ -44,7 +44,7 @@ cd ..
 cd widgets
 yarn
 export SVG_MIN_CRED=0.5
-export SVG_MAX_USERS=50
+export SVG_MAX_USERS=80
 for repo in $REPOS; do
 	echo "Generating ${repo//\//-}-contributors.svg"
 	# Buffer the score output to a file to prevent occasional read errors from STDIN.

--- a/scripts/local-generate-svg.sh
+++ b/scripts/local-generate-svg.sh
@@ -43,7 +43,7 @@ cd ..
 # Generate our widgets using the scores.json export format.
 cd widgets
 yarn
-export SVG_MIN_CRED=4.5
+export SVG_MIN_CRED=0.5
 export SVG_MAX_USERS=50
 for repo in $REPOS; do
 	echo "Generating ${repo//\//-}-contributors.svg"

--- a/scripts/rebuild-site.sh
+++ b/scripts/rebuild-site.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 CNAME="${CNAME:-"sfosc.org"}"
-SVG_MIN_CRED=${SVG_MIN_CRED:-4.5}
+SVG_MIN_CRED=${SVG_MIN_CRED:-0.5}
 SVG_MAX_USERS=${SVG_MAX_USERS:-50}
 
 toplevel="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"

--- a/scripts/rebuild-site.sh
+++ b/scripts/rebuild-site.sh
@@ -2,7 +2,7 @@
 
 CNAME="${CNAME:-"sfosc.org"}"
 SVG_MIN_CRED=${SVG_MIN_CRED:-0.5}
-SVG_MAX_USERS=${SVG_MAX_USERS:-50}
+SVG_MAX_USERS=${SVG_MAX_USERS:-80}
 
 toplevel="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
 cd "${toplevel}"


### PR DESCRIPTION
I've done some investigation of the 4.5 minimum cred threshold after the v0.4.0 sourcecred update.

At the time I've set the 4.5 value to filter users who gained cred just from a :+1: reaction to a comment or similar. But now some contributions we should credit in my opinion were being left out.

For example, currently the lowest cred score to meet the new 0.5 threshold is
@joehand receiving 0.89 cred for this comment https://github.com/sfosc/sfosc/issues/5#issuecomment-452755461

A sample of others who were previously left out,
@jsmanrique who raised https://github.com/sfosc/sfosc/issues/15 and added a follow up comment resulting in 2.27 cred.
@jgannondo who submitted https://github.com/sfosc/sfosc/pull/55 received 4.13 cred.
@jonsmorrow who submitted https://github.com/sfosc/sfosc/pull/57 received 4.13 cred.

While 4 users who've only contributed a github reaction (:+1: or :heart: in this case) are attributed 0.0 cred.

_Note: I've used the `bin/sourcecred.js scores` command to look at users `totalCred` in `@sfosc` before rounding, with our [custom weights](https://github.com/sfosc/sourcecred/blob/master/weights.toml) applied during load. And the [legacy explorer](https://sfosc.org/sourcecred/prototype/@sfosc/) to find which contributions people made._