### PR TITLE
Add caching to Drone pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,35 +28,26 @@ steps:
     settings:
       restore: true
       cache_key: update-github-pages
+      # Each mount path is stored individually, so you can split them later
+      # without needing a separate cache_key for each of them.
       mount:
         - './sourcecred_data/cache'
         - './sourcecred/node_modules'
         - './widgets/node_modules'
 
-  # - name: build
-  #   image: node:10
-  #   environment:
-  #     SOURCECRED_GITHUB_TOKEN:
-  #       from_secret: SOURCECRED_GITHUB_TOKEN
-  #     SSH_BOT_KEY:
-  #       from_secret: SSH_BOT_KEY
-  #   commands:
-  #     # Use a bot key for reading.
-  #     - mkdir -p ~/.ssh
-  #     - ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-  #     - echo "$SSH_BOT_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa
-  #     - ./scripts/rebuild-site.sh
-
-  - name: build-dummy
+  - name: build
     image: node:10
+    environment:
+      SOURCECRED_GITHUB_TOKEN:
+        from_secret: SOURCECRED_GITHUB_TOKEN
+      SSH_BOT_KEY:
+        from_secret: SSH_BOT_KEY
     commands:
-      - mkdir -p sourcecred_data/cache sourcecred/node_modules widgets/node_modules
-      - ls -l sourcecred_data/cache
-      - ls -l sourcecred/node_modules
-      - ls -l widgets/node_modules
-      - touch sourcecred_data/cache/testing-cache
-      - touch sourcecred/node_modules/testing-cache
-      - touch widgets/node_modules/testing-cache
+      # Use a bot key for reading.
+      - mkdir -p ~/.ssh
+      - ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - echo "$SSH_BOT_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa
+      - ./scripts/rebuild-site.sh
 
   - name: rebuild-cache-sourcecred
     image: meltwater/drone-cache:1
@@ -77,23 +68,23 @@ steps:
         - './sourcecred/node_modules'
         - './widgets/node_modules'
 
-  # - name: commit-and-push
-  #   image: docker:git
-  #   environment:
-  #     SSH_DEPLOY_KEY:
-  #       from_secret: SSH_DEPLOY_KEY
-  #   commands:
-  #     # Switch to the secret deploy key.
-  #     - mkdir -p ~/.ssh
-  #     - ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-  #     - echo "$SSH_DEPLOY_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa
-  #     - cd site
-  #     - git init
-  #     - git config user.email "bot@sfosc.org"
-  #     - git config user.name "Deployment Bot"
-  #     - git checkout -b gh-pages
-  #     - git add --all
-  #     - git commit -m "Publishing to gh-pages `date`"
+  - name: commit-and-push
+    image: docker:git
+    environment:
+      SSH_DEPLOY_KEY:
+        from_secret: SSH_DEPLOY_KEY
+    commands:
+      # Switch to the secret deploy key.
+      - mkdir -p ~/.ssh
+      - ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - echo "$SSH_DEPLOY_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa
+      - cd site
+      - git init
+      - git config user.email "bot@sfosc.org"
+      - git config user.name "Deployment Bot"
+      - git checkout -b gh-pages
+      - git add --all
+      - git commit -m "Publishing to gh-pages `date`"
       # - git push -f git@github.com:sfosc/sourcecred.git gh-pages
 
 # trigger:

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,18 +14,22 @@ steps:
 
   - name: restore-cache
     image: meltwater/drone-cache:1
+    environment: &minio-cache-env
+      S3_ENDPOINT: https://minio.sfosc.robin-it.com
+      S3_REGION: eu-west-1
+      S3_BUCKET: drone-cache_${DRONE_REPO_NAMESPACE}-${DRONE_REPO_NAME}
+      PLUGIN_ACCESS_KEY:
+        from_secret: MINIO_ACCESS_KEY
+      PLUGIN_SECRET_KEY:
+        from_secret: MINIO_SECRET_KEY
     settings:
       restore: true
-      cache_key: '{{ .Repo.Namespace }}-{{ .Repo.Name }}/cron-cache'
-      backend: filesystem
+      cache_key: ${DRONE_STAGE_NAME}
       archive_format: gzip
       mount:
         - './sourcecred_data/cache'
         - './sourcecred/node_modules'
         - './widgets/node_modules'
-    volumes:
-      - name: cache
-        path: /tmp/cache
 
   - name: build
     image: node:10
@@ -43,18 +47,15 @@ steps:
 
   - name: rebuild-cache
     image: meltwater/drone-cache:1
+    environment: *minio-cache-env
     settings:
       rebuild: true
-      cache_key: '{{ .Repo.Namespace }}-{{ .Repo.Name }}/cron-cache'
-      backend: filesystem
+      cache_key: ${DRONE_STAGE_NAME}
       archive_format: gzip
       mount:
         - './sourcecred_data/cache'
         - './sourcecred/node_modules'
         - './widgets/node_modules'
-    volumes:
-      - name: cache
-        path: /tmp/cache
 
   - name: commit-and-push
     image: docker:git
@@ -73,13 +74,8 @@ steps:
       - git checkout -b gh-pages
       - git add --all
       - git commit -m "Publishing to gh-pages `date`"
-      - git push -f git@github.com:sfosc/sourcecred.git gh-pages
+      # - git push -f git@github.com:sfosc/sourcecred.git gh-pages
 
-trigger:
-  branch:
-    - master
-
-volumes:
-  - name: cache
-    host:
-      path: /var/cache/drone
+# trigger:
+#   branch:
+#     - master

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,6 +12,21 @@ steps:
       - git submodule init
       - git submodule update
 
+  - name: restore-cache
+    image: meltwater/drone-cache:1
+    settings:
+      restore: true
+      cache_key: '{{ .Repo.Namespace }}-{{ .Repo.Name }}/cron-cache'
+      backend: filesystem
+      archive_format: gzip
+      mount:
+        - './sourcecred_data/cache'
+        - './sourcecred/node_modules'
+        - './widgets/node_modules'
+    volumes:
+      - name: cache
+        path: /tmp/cache
+
   - name: build
     image: node:10
     environment:
@@ -25,6 +40,21 @@ steps:
       - ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - echo "$SSH_BOT_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa
       - ./scripts/rebuild-site.sh
+
+  - name: rebuild-cache
+    image: meltwater/drone-cache:1
+    settings:
+      rebuild: true
+      cache_key: '{{ .Repo.Namespace }}-{{ .Repo.Name }}/cron-cache'
+      backend: filesystem
+      archive_format: gzip
+      mount:
+        - './sourcecred_data/cache'
+        - './sourcecred/node_modules'
+        - './widgets/node_modules'
+    volumes:
+      - name: cache
+        path: /tmp/cache
 
   - name: commit-and-push
     image: docker:git
@@ -43,8 +73,13 @@ steps:
       - git checkout -b gh-pages
       - git add --all
       - git commit -m "Publishing to gh-pages `date`"
-      - git push -f git@github.com:sfosc/sourcecred.git gh-pages
+      # - git push -f git@github.com:sfosc/sourcecred.git gh-pages
 
-trigger:
-  branch:
-    - master
+# trigger:
+#   branch:
+#     - master
+
+volumes:
+  - name: cache
+    host:
+      path: /var/cache/drone

--- a/.drone.yml
+++ b/.drone.yml
@@ -49,7 +49,7 @@ steps:
       - echo "$SSH_BOT_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa
       - ./scripts/rebuild-site.sh
 
-  - name: rebuild-cache-sourcecred
+  - name: rebuild-cache
     image: meltwater/drone-cache:1
     environment: *minio-cache-env
     settings:
@@ -57,14 +57,6 @@ steps:
       cache_key: update-github-pages
       mount:
         - './sourcecred_data/cache'
-
-  - name: rebuild-cache-node-modules
-    image: meltwater/drone-cache:1
-    environment: *minio-cache-env
-    settings:
-      rebuild: true
-      cache_key: update-github-pages
-      mount:
         - './sourcecred/node_modules'
         - './widgets/node_modules'
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -73,11 +73,11 @@ steps:
       - git checkout -b gh-pages
       - git add --all
       - git commit -m "Publishing to gh-pages `date`"
-      # - git push -f git@github.com:sfosc/sourcecred.git gh-pages
+      - git push -f git@github.com:sfosc/sourcecred.git gh-pages
 
-# trigger:
-#   branch:
-#     - master
+trigger:
+  branch:
+    - master
 
 volumes:
   - name: cache

--- a/.drone.yml
+++ b/.drone.yml
@@ -79,8 +79,8 @@ steps:
       - git checkout -b gh-pages
       - git add --all
       - git commit -m "Publishing to gh-pages `date`"
-      # - git push -f git@github.com:sfosc/sourcecred.git gh-pages
+      - git push -f git@github.com:sfosc/sourcecred.git gh-pages
 
-# trigger:
-#   branch:
-#     - master
+trigger:
+  branch:
+    - master

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,63 +17,83 @@ steps:
     environment: &minio-cache-env
       S3_ENDPOINT: https://minio.sfosc.robin-it.com
       S3_REGION: eu-west-1
-      S3_BUCKET: drone-cache_${DRONE_REPO_NAMESPACE}-${DRONE_REPO_NAME}
+      S3_BUCKET: drone-cache-sfosc
+      # Path style buckets is used for minio hosts, AWS S3 should be false
+      PLUGIN_PATH_STYLE: true
+      PLUGIN_ARCHIVE_FORMAT: gzip
       PLUGIN_ACCESS_KEY:
         from_secret: MINIO_ACCESS_KEY
       PLUGIN_SECRET_KEY:
         from_secret: MINIO_SECRET_KEY
     settings:
       restore: true
-      cache_key: ${DRONE_STAGE_NAME}
-      archive_format: gzip
+      cache_key: update-github-pages
       mount:
         - './sourcecred_data/cache'
         - './sourcecred/node_modules'
         - './widgets/node_modules'
 
-  - name: build
-    image: node:10
-    environment:
-      SOURCECRED_GITHUB_TOKEN:
-        from_secret: SOURCECRED_GITHUB_TOKEN
-      SSH_BOT_KEY:
-        from_secret: SSH_BOT_KEY
-    commands:
-      # Use a bot key for reading.
-      - mkdir -p ~/.ssh
-      - ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-      - echo "$SSH_BOT_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa
-      - ./scripts/rebuild-site.sh
+  # - name: build
+  #   image: node:10
+  #   environment:
+  #     SOURCECRED_GITHUB_TOKEN:
+  #       from_secret: SOURCECRED_GITHUB_TOKEN
+  #     SSH_BOT_KEY:
+  #       from_secret: SSH_BOT_KEY
+  #   commands:
+  #     # Use a bot key for reading.
+  #     - mkdir -p ~/.ssh
+  #     - ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+  #     - echo "$SSH_BOT_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa
+  #     - ./scripts/rebuild-site.sh
 
-  - name: rebuild-cache
+  - name: build-dummy
+    image: node:10
+    commands:
+      - mkdir -p sourcecred_data/cache sourcecred/node_modules widgets/node_modules
+      - ls -l sourcecred_data/cache
+      - ls -l sourcecred/node_modules
+      - ls -l widgets/node_modules
+      - touch sourcecred_data/cache/testing-cache
+      - touch sourcecred/node_modules/testing-cache
+      - touch widgets/node_modules/testing-cache
+
+  - name: rebuild-cache-sourcecred
     image: meltwater/drone-cache:1
     environment: *minio-cache-env
     settings:
       rebuild: true
-      cache_key: ${DRONE_STAGE_NAME}
-      archive_format: gzip
+      cache_key: update-github-pages
       mount:
         - './sourcecred_data/cache'
+
+  - name: rebuild-cache-node-modules
+    image: meltwater/drone-cache:1
+    environment: *minio-cache-env
+    settings:
+      rebuild: true
+      cache_key: update-github-pages
+      mount:
         - './sourcecred/node_modules'
         - './widgets/node_modules'
 
-  - name: commit-and-push
-    image: docker:git
-    environment:
-      SSH_DEPLOY_KEY:
-        from_secret: SSH_DEPLOY_KEY
-    commands:
-      # Switch to the secret deploy key.
-      - mkdir -p ~/.ssh
-      - ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-      - echo "$SSH_DEPLOY_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa
-      - cd site
-      - git init
-      - git config user.email "bot@sfosc.org"
-      - git config user.name "Deployment Bot"
-      - git checkout -b gh-pages
-      - git add --all
-      - git commit -m "Publishing to gh-pages `date`"
+  # - name: commit-and-push
+  #   image: docker:git
+  #   environment:
+  #     SSH_DEPLOY_KEY:
+  #       from_secret: SSH_DEPLOY_KEY
+  #   commands:
+  #     # Switch to the secret deploy key.
+  #     - mkdir -p ~/.ssh
+  #     - ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+  #     - echo "$SSH_DEPLOY_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa
+  #     - cd site
+  #     - git init
+  #     - git config user.email "bot@sfosc.org"
+  #     - git config user.name "Deployment Bot"
+  #     - git checkout -b gh-pages
+  #     - git add --all
+  #     - git commit -m "Publishing to gh-pages `date`"
       # - git push -f git@github.com:sfosc/sourcecred.git gh-pages
 
 # trigger:

--- a/.drone.yml
+++ b/.drone.yml
@@ -51,6 +51,8 @@ steps:
 
   - name: rebuild-cache
     image: meltwater/drone-cache:1
+    # This is called an alias (the *name), and references an anchor (the &name) for reusing it's values.
+    # It's part of the YAML specification.
     environment: *minio-cache-env
     settings:
       rebuild: true

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -56,3 +56,24 @@ This secret needs to hold the _private key_ part, and should be RSA only.
 The public part of the key is configured at https://github.com/sfosc/sourcecred/settings/keys.
 
 You can generate a new RSA keypair using `ssh-keygen -f deploy-key`.
+
+### Caching
+
+For caching we currently cache:
+
+- `./sourcecred_data/cache`
+- `./sourcecred/node_modules`
+- `./widgets/node_modules`
+
+The sourcecred data cache stores information we would retrieve from the GitHub API and saves a lot of calls there
+as you don't need to download the entire history of your repositories again, only changes since the last run.
+The node_modules speed up yarn installs. Particularly the `better-sqlite3` dependency, which compiles from source
+with node-gyp and takes several minutes to do so.
+
+The current Drone configuration also uses ["host volumes"](https://docker-runner.docs.drone.io/configuration/volumes/host/)
+for this. This is only available when you self-host a Drone instance because:
+
+>  This setting is only available to trusted repositories, since mounting host machine volumes is a security risk.
+
+In a different environment you may need to adjust the configuration to use a different storage backend instead.
+For example AWS S3, which is supported by the caching plugin used: [meltwater/drone-cache](https://github.com/meltwater/drone-cache/blob/master/docs/examples/drone-1.0.md).

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -65,15 +65,10 @@ For caching we currently cache:
 - `./sourcecred/node_modules`
 - `./widgets/node_modules`
 
-The sourcecred data cache stores information we would retrieve from the GitHub API and saves a lot of calls there
+The sourcecred data cache stores information we would retrieve from the GitHub API and saves a lot of calls there,
 as you don't need to download the entire history of your repositories again, only changes since the last run.
 The node_modules speed up yarn installs. Particularly the `better-sqlite3` dependency, which compiles from source
 with node-gyp and takes several minutes to do so.
 
-The current Drone configuration also uses ["host volumes"](https://docker-runner.docs.drone.io/configuration/volumes/host/)
-for this. This is only available when you self-host a Drone instance because:
-
->  This setting is only available to trusted repositories, since mounting host machine volumes is a security risk.
-
-In a different environment you may need to adjust the configuration to use a different storage backend instead.
-For example AWS S3, which is supported by the caching plugin used: [meltwater/drone-cache](https://github.com/meltwater/drone-cache/blob/master/docs/examples/drone-1.0.md).
+Drone does not support a _safe_ local caching mechanism out of the box. So we're adding a self-hosted [minio](https://min.io/) instance
+and configured the caching plugin: [meltwater/drone-cache](https://github.com/meltwater/drone-cache/blob/master/docs/examples/drone-1.0.md).


### PR DESCRIPTION
I've done a dry run here:
https://drone.sfosc.robin-it.com/sfosc/sourcecred/85 (7m 30s) before cache was populated
https://drone.sfosc.robin-it.com/sfosc/sourcecred/86 (2m 5s) after cache was populated

Initially I've created the `/var/cache/drone` directory on the host machine and marked this repository as trusted in Drone. The security risk of doing so is other write-access contributors can try to access arbitrary locations on the host machine by updating the drone configuration. Such as `/root/.ssh`.

As I would like other people to have access to this repository without having to constantly look for safe usage of the drone config, I decided to deploy a self-hosted [minio](https://min.io/) instance for caching instead.

(Also I intend to squash this PR)